### PR TITLE
Fix/error catching get queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,16 @@ The app needs sqs list and read access to the sqs policies
 
 ## Running
 
-**You need to specify the region to connect to**
+To run the SQS exporter on Docker, you need to specify the region to connect to.
 
-Running on an ec2 machine using IAM roles:
-`docker run -e AWS_REGION=<region> -d -p 9434:9434 ashiddo11/sqs-exporter`
+When running on an ec2 machine using IAM role:
 
-Or running it externally:
-`docker run -d -p 9434:9434 -e AWS_ACCESS_KEY_ID=<access_key> -e AWS_SECRET_ACCESS_KEY=<secret_key> -e AWS_REGION=<region>  ashiddo11/sqs-exporter`
+```
+$ docker run -e AWS_REGION=<region> -d -p 9434:9434 ashiddo11/sqs-exporter
+```
+
+When running it externally:
+
+```
+$ docker run -d -p 9434:9434 -e AWS_ACCESS_KEY_ID=<access_key> -e AWS_SECRET_ACCESS_KEY=<secret_key> -e AWS_REGION=<region>  ashiddo11/sqs-exporter
+```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ The app needs sqs list and read access to the sqs policies
 
 ## Running
 
-**You need to specify the region you to connect to**
+**You need to specify the region to connect to**
+
 Running on an ec2 machine using IAM roles:
 `docker run -e AWS_REGION=<region> -d -p 9434:9434 ashiddo11/sqs-exporter`
 
 Or running it externally:
-`docker run -d -p 9384:9384 -e AWS_ACCESS_KEY_ID=<access_key> -e AWS_SECRET_ACCESS_KEY=<secret_key> -e AWS_REGION=<region>  ashiddo11/sqs-exporter`
+`docker run -d -p 9434:9434 -e AWS_ACCESS_KEY_ID=<access_key> -e AWS_SECRET_ACCESS_KEY=<secret_key> -e AWS_REGION=<region>  ashiddo11/sqs-exporter`

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -2,18 +2,19 @@ package collector
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 type MetricHandler struct{}
 
 func (h MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	queues,listQueueTags := getQueues()
+	queues, listQueueTags := getQueues()
 	for queue, attr := range queues {
 		msgAvailable := *attr.Attributes["ApproximateNumberOfMessages"]
 		msgDelayed := *attr.Attributes["ApproximateNumberOfMessagesDelayed"]
@@ -62,11 +63,13 @@ func getQueues() (queues map[string]*sqs.GetQueueAttributesOutput, tags map[stri
 			QueueUrl: aws.String(*urls),
 		}
 
-		resp, _ := client.GetQueueAttributes(params)
-		tagsResp, _ := client.ListQueueTags(tagsParams)
 		queueName := getQueueName(*urls)
-		queues[queueName] = resp
-		tags[queueName] = tagsResp
+		resp, _ := client.GetQueueAttributes(params)
+		tagsResp, err := client.ListQueueTags(tagsParams)
+		if err == nil {
+			queues[queueName] = resp
+			tags[queueName] = tagsResp
+		}
 	}
-	return queues,tags
+	return queues, tags
 }


### PR DESCRIPTION
Check for error before adding results in the maps. It can occur when some queues are under deletion, especially with a great number of queues.
Also updated doc (port number and command line format).