### PR TITLE
Add support for queue name filter

### DIFF
--- a/collector/options.go
+++ b/collector/options.go
@@ -1,0 +1,5 @@
+package collector
+
+type Options struct {
+	QueueMatcher string
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -19,10 +20,15 @@ func main() {
 	var (
 		listenAddress = flag.String("web.listen-address", ":9434", "Address to listen on for web interface and telemetry.")
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+		queueMatcherRe   = flag.String("sqs.queue-filter", "(.*)", "Regex filter for sqs queue name")
 	)
 	flag.Parse()
 
-	http.Handle(*metricsPath, collector.MetricHandler{})
+	fmt.Println(*queueMatcherRe)
+
+	http.Handle(*metricsPath, collector.MetricHandler{
+		Opts: &collector.Options{QueueMatcher: *queueMatcherRe},
+	})
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`
 	        <html>

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 
@@ -23,8 +22,6 @@ func main() {
 		queueMatcherRe   = flag.String("sqs.queue-filter", "(.*)", "Regex filter for sqs queue name")
 	)
 	flag.Parse()
-
-	fmt.Println(*queueMatcherRe)
 
 	http.Handle(*metricsPath, collector.MetricHandler{
 		Opts: &collector.Options{QueueMatcher: *queueMatcherRe},


### PR DESCRIPTION
This add support for filtering queue names retrieved by the MetricsCollector using go stdlib flags.
This solves #10  